### PR TITLE
Add Chatwoot webhook integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This project creates a WhatsApp bot that integrates with an AI assistant using B
 - Real-time message receiving and responding
 - Interaction tracking with customers
 - Expandable functionality through triggers
+- Optional Chatwoot webhook integration for conversation logging
 
 ## Getting Started
 
@@ -29,6 +30,8 @@ This project creates a WhatsApp bot that integrates with an AI assistant using B
    ```
    PORT=3008
    ASSISTANT_ID=your_openai_assistant_id
+   CHATWOOT_WEBHOOK_URL=https://your-chatwoot.example/webhook
+   CHATWOOT_TOKEN=optional_api_token
    ```
 4. Run the development server:
    ```

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,6 @@
+import { createRequire } from 'module'
+import { FlatCompat } from '@eslint/eslintrc'
+const require = createRequire(import.meta.url)
+const eslintrc = require('./.eslintrc.json')
+const compat = new FlatCompat({ recommendedConfig: {}, allConfig: {} })
+export default compat.config(eslintrc)

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "dotenv": "^16.4.5"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.3.1",
     "@types/multer": "^1.4.11",
     "@types/node": "^20.11.30",
     "@typescript-eslint/eslint-plugin": "^7.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,11 +16,14 @@ importers:
         version: 1.2.9
       '@builderbot/provider-baileys':
         specifier: 1.2.9
-        version: 1.2.9(audio-decode@2.2.0)(eslint@8.57.0)(sharp@0.33.3)(typescript@5.4.5)
+        version: 1.2.9(audio-decode@2.2.0)(eslint@8.57.0)(typescript@5.4.5)
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
     devDependencies:
+      '@eslint/eslintrc':
+        specifier: ^3.3.1
+        version: 3.3.1
       '@types/multer':
         specifier: ^1.4.11
         version: 1.4.11
@@ -243,6 +246,10 @@ packages:
   '@eslint/eslintrc@2.1.4':
     resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@eslint/eslintrc@3.3.1':
+    resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/js@8.57.0':
     resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
@@ -785,6 +792,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agentkeepalive@4.5.0:
     resolution: {integrity: sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==}
     engines: {node: '>= 8.0.0'}
@@ -1072,10 +1084,18 @@ packages:
     resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint@8.57.0:
     resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
@@ -1220,6 +1240,10 @@ packages:
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
     engines: {node: '>=8'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
 
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
@@ -1957,12 +1981,12 @@ snapshots:
       - debug
       - supports-color
 
-  '@builderbot/provider-baileys@1.2.9(audio-decode@2.2.0)(eslint@8.57.0)(sharp@0.33.3)(typescript@5.4.5)':
+  '@builderbot/provider-baileys@1.2.9(audio-decode@2.2.0)(eslint@8.57.0)(typescript@5.4.5)':
     dependencies:
       '@adiwajshing/keyed-db': 0.2.4
       '@ffmpeg-installer/ffmpeg': 1.1.0
       '@types/polka': 0.5.7
-      baileys: 6.7.18(audio-decode@2.2.0)(eslint@8.57.0)(sharp@0.33.3)(typescript@5.4.5)
+      baileys: 6.7.18(audio-decode@2.2.0)(eslint@8.57.0)(typescript@5.4.5)
       fluent-ffmpeg: 2.1.2
       fs-extra: 11.2.0
       node-cache: 5.1.2
@@ -2076,9 +2100,23 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.6
       espree: 9.6.1
       globals: 13.24.0
+      ignore: 5.3.1
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/eslintrc@3.3.1':
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.3.6
+      espree: 10.4.0
+      globals: 14.0.0
       ignore: 5.3.1
       import-fresh: 3.3.0
       js-yaml: 4.1.0
@@ -2133,7 +2171,7 @@ snapshots:
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.6
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -2515,7 +2553,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.7.1
       '@typescript-eslint/visitor-keys': 7.7.1
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.6
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.4
@@ -2627,7 +2665,13 @@ snapshots:
     dependencies:
       acorn: 8.11.3
 
+  acorn-jsx@5.3.2(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
+
   acorn@8.11.3: {}
+
+  acorn@8.15.0: {}
 
   agentkeepalive@4.5.0:
     dependencies:
@@ -2693,7 +2737,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  baileys@6.7.18(audio-decode@2.2.0)(eslint@8.57.0)(sharp@0.33.3)(typescript@5.4.5):
+  baileys@6.7.18(audio-decode@2.2.0)(eslint@8.57.0)(typescript@5.4.5):
     dependencies:
       '@cacheable/node-cache': 1.5.5
       '@hapi/boom': 9.1.4
@@ -2708,7 +2752,6 @@ snapshots:
       ws: 8.18.0
     optionalDependencies:
       audio-decode: 2.2.0
-      sharp: 0.33.3
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -2950,6 +2993,8 @@ snapshots:
 
   eslint-visitor-keys@4.2.0: {}
 
+  eslint-visitor-keys@4.2.1: {}
+
   eslint@8.57.0:
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
@@ -2992,6 +3037,12 @@ snapshots:
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      eslint-visitor-keys: 4.2.1
 
   espree@9.6.1:
     dependencies:
@@ -3144,6 +3195,8 @@ snapshots:
   globals@13.24.0:
     dependencies:
       type-fest: 0.20.2
+
+  globals@14.0.0: {}
 
   globby@11.1.0:
     dependencies:

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import { MemoryDB } from '@builderbot/bot'
 import { BaileysProvider } from '@builderbot/provider-baileys'
 import { toAsk, httpInject } from "@builderbot-plugins/openai-assistants"
 import { typing } from "./utils/presence"
+import { sendChatwootMessage } from "./utils/chatwoot"
 
 const PORT = process.env.PORT ?? 3008
 const ASSISTANT_ID = process.env.ASSISTANT_ID ?? ''
@@ -17,6 +18,7 @@ const DISABLED_USERS = new Set([
 
 const processUserMessage = async (ctx, { flowDynamic, state, provider }) => {
     await typing(ctx, provider);
+    await sendChatwootMessage(ctx.from, ctx.body, false);
     const response = await toAsk(ASSISTANT_ID, ctx.body, state);
 
     const chunks = response.split(/\n\n+/);
@@ -95,6 +97,7 @@ for (const url of docUrls) {
 
         if (cleanedText !== '') {
             await flowDynamic([{ body: cleanedText }]);
+            await sendChatwootMessage(ctx.from, cleanedText, true);
         }
     }
 };

--- a/src/utils/chatwoot.ts
+++ b/src/utils/chatwoot.ts
@@ -1,0 +1,26 @@
+const CHATWOOT_WEBHOOK_URL = process.env.CHATWOOT_WEBHOOK_URL || ''
+const CHATWOOT_TOKEN = process.env.CHATWOOT_TOKEN || ''
+
+export const sendChatwootMessage = async (
+    userId: string,
+    message: string,
+    fromMe: boolean
+) => {
+    if (!CHATWOOT_WEBHOOK_URL) return
+    try {
+        const res = await fetch(CHATWOOT_WEBHOOK_URL, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                ...(CHATWOOT_TOKEN && { Authorization: `Bearer ${CHATWOOT_TOKEN}` })
+            },
+            body: JSON.stringify({ user_id: userId, message, from_me: fromMe })
+        })
+        if (!res.ok) {
+            const text = await res.text()
+            console.error('❌ Error enviando a Chatwoot:', text)
+        }
+    } catch (err: any) {
+        console.error('❌ Error enviando a Chatwoot:', err.message)
+    }
+}


### PR DESCRIPTION
## Summary
- add optional Chatwoot webhook helpers
- send incoming/outgoing messages to Chatwoot
- document environment vars and feature in README
- add ESLint compat config
- include @eslint/eslintrc for linting

## Testing
- `pnpm exec eslint . --no-ignore`

------
https://chatgpt.com/codex/tasks/task_e_68590124487c83249e7dd17459afbf57