### PR TITLE
Add Flask Selfie Mirror server and fix media send flag

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,46 @@
+from flask import Flask, request, jsonify, send_from_directory
+import base64, requests, os
+
+OPENAI_KEY = os.getenv("OPENAI_API_KEY")
+app = Flask(__name__, static_folder="static")
+
+@app.route("/")
+def home():
+    return send_from_directory("static", "index.html")
+
+@app.route("/process", methods=["POST"])
+def process():
+    file = request.files.get("foto")
+    prompt = request.form.get("prompt", "Efecto Selfie Mirror brillante")
+
+    if not file:
+        return jsonify({"error": "No se recibió imagen"}), 400
+
+    img_b64 = base64.b64encode(file.read()).decode()
+
+    payload = {
+        "model": "gpt-image-1",
+        "prompt": prompt,
+        "size": "512x512",
+        "image": img_b64
+    }
+
+    headers = {
+        "Authorization": f"Bearer {OPENAI_KEY}",
+        "Content-Type": "application/json"
+    }
+
+    try:
+        r = requests.post("https://api.openai.com/v1/images/generations",
+                          headers=headers, json=payload, timeout=60)
+        data = r.json()
+    except Exception as e:
+        return jsonify({"error": f"Error de red: {e}"}), 500
+
+    if r.status_code == 200 and "data" in data:
+        return jsonify({"b64": data["data"][0]["b64_json"]})
+    else:
+        return jsonify({"error": f"HTTP {r.status_code}", "raw": data}), 500
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8080)

--- a/src/app.ts
+++ b/src/app.ts
@@ -28,13 +28,14 @@ const processUserMessage = async (ctx, { flowDynamic, state, provider }) => {
 
         let enviado = false;
 
-for (const url of mediaUrls) {
-    try {
-        await provider.sendMedia(ctx.from, url, { caption: '' });
-    } catch (err) {
-        console.error('❌ Error al enviar media:', err.message);
-    }
-}
+        for (const url of urls) {
+            try {
+                await provider.sendMedia(ctx.from, url, { caption: '' });
+                enviado = true;
+            } catch (err) {
+                console.error('❌ Error al enviar media:', err.message);
+            }
+        }
 
         if (!enviado && cleanedChunk !== '') {
             await flowDynamic([{ body: cleanedChunk }]);

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Selfie Mirror IA Railway</title>
+  <style>
+    body { font-family: Arial; text-align:center; background:#111; color:#fff; }
+    video, canvas, img { max-width: 320px; margin:10px; border-radius: 10px; }
+    input, button { margin: 10px; padding: 10px; font-size: 16px; width:80%; }
+    #logs { text-align:left; max-width: 600px; margin:auto; background:#222; color:#0f0; font-size:12px; padding:10px; }
+  </style>
+</head>
+<body>
+  <h1>Selfie Mirror IA</h1>
+  <input type="text" id="prompt" placeholder="Escribe tu prompt IA...">
+  <br>
+  <video id="video" autoplay playsinline></video>
+  <canvas id="canvas" style="display:none;"></canvas>
+  <br>
+  <button id="captureBtn">📸 Capturar y Procesar</button>
+  <div id="result"></div>
+  <pre id="logs"></pre>
+
+  <script>
+    const video = document.getElementById('video');
+    const canvas = document.getElementById('canvas');
+    const result = document.getElementById('result');
+    const logs = document.getElementById('logs');
+
+    function logMsg(msg){
+      logs.textContent += msg + "\n";
+    }
+
+    navigator.mediaDevices.getUserMedia({ video: true })
+      .then(stream => video.srcObject = stream)
+      .catch(err => logMsg("Error cámara: " + err));
+
+    document.getElementById('captureBtn').addEventListener('click', () => {
+      const ctx = canvas.getContext('2d');
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+      ctx.drawImage(video, 0, 0);
+
+      const prompt = document.getElementById('prompt').value || "Efecto Selfie Mirror brillante";
+
+      canvas.toBlob(blob => {
+        const formData = new FormData();
+        formData.append('foto', blob, 'captura.png');
+        formData.append('prompt', prompt);
+
+        logMsg("📤 Enviando imagen a Railway...");
+        result.innerHTML = "<p>Procesando imagen con IA...</p>";
+
+        fetch('/process', { method: 'POST', body: formData })
+          .then(r => r.json())
+          .then(data => {
+            if(data.b64){
+              const img = new Image();
+              img.src = 'data:image/png;base64,' + data.b64;
+              result.innerHTML = '';
+              result.appendChild(img);
+              logMsg("✅ Imagen recibida");
+            } else {
+              result.innerHTML = 'Error: ' + JSON.stringify(data);
+              logMsg("❌ " + JSON.stringify(data));
+            }
+          })
+          .catch(err => logMsg("❌ Fetch error: " + err));
+      }, 'image/png');
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask server (`app.py`) to generate images using OpenAI API
- include webcam capture frontend in `static/index.html`
- fix media sending loop and lint flag in `src/app.ts`

## Testing
- `python -m py_compile app.py`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68902aa99a488324975e53c33b08b0b1